### PR TITLE
Updated index.js to close navbar when clicked on a link for all pages

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -22,3 +22,11 @@ $("#faqaccordion").on("hide.bs.collapse show.bs.collapse", e => {
       .find("i:last-child")
       .toggleClass("fa-minus fa-plus");
   });
+
+//close navbar when clicked on link
+const navLinks = document.querySelectorAll('.nav-item')
+const menuToggle = document.getElementById('navbarSupportedContent')
+const bsCollapse = new bootstrap.Collapse(menuToggle)
+navLinks.forEach((l) => {
+    l.addEventListener('click', () => { bsCollapse.toggle() })
+})


### PR DESCRIPTION
# Description
When we click on the buttons/links in the navbar like contact/about, it just scrolls down in the page but the navbar doesn't close and thus overlaps on the other elements. (in phone view). I have updated the index.js to close the navbar when clicked on a link for all pages
Fixes #406

## List any dependencies that are required for this change 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

## UI /UX changes
   Attach gif or screenshot for changes.
   - Before :
![Screenshot (178)](https://user-images.githubusercontent.com/56400099/115150268-42fe7900-a085-11eb-8b8f-f8b0865f5ca8.png)

   - After :
   ![Screenshot (177)](https://user-images.githubusercontent.com/56400099/115150271-45f96980-a085-11eb-9b3d-7a16f38b6274.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


