### PR TITLE
Fixed Image and data not being hidden on page flip in team.html in Firefox browser

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -505,15 +505,6 @@ HEAD .round-2 {
   transform: rotateY(-180deg);
 }
 
-/*Fixes card flip issue in firefox*/
-.flip-card-front, .flip-card-back {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  backface-visibility: hidden;
-  transform: rotateX(0deg);
-}
-
 /* Position the front and back side */
 .flip-card-front,
 .flip-card-back {
@@ -522,6 +513,7 @@ HEAD .round-2 {
   height: 100%;
   -webkit-backface-visibility: hidden; /* Safari */
   backface-visibility: hidden;
+  transform: rotateX(0deg); /* Fixes card flip issue in firefox */
 }
 
 /* Style the front side (fallback if image is missing) */

--- a/css/style.css
+++ b/css/style.css
@@ -505,6 +505,15 @@ HEAD .round-2 {
   transform: rotateY(-180deg);
 }
 
+/*Fixes card flip issue in firefox*/
+.flip-card-front, .flip-card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  transform: rotateX(0deg);
+}
+
 /* Position the front and back side */
 .flip-card-front,
 .flip-card-back {


### PR DESCRIPTION
# Description

Fixed Image and data not being hidden on page flip in team.html in Firefox browser
Fixes #457

## List any dependencies that are required for this change 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

## UI /UX changes
   Attach gif or screenshot for changes.
   - Before :
   
![Screenshot (197)](https://user-images.githubusercontent.com/56400099/117784806-90739d80-b261-11eb-80fa-e3b4a26fead5.png)

   - After :
![Screenshot (196)](https://user-images.githubusercontent.com/56400099/117784827-97021500-b261-11eb-84fa-ed330c5f9ba8.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


